### PR TITLE
Build System Changes to Support Clang on OS X

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -21,7 +21,7 @@ set(CMAKE_CXX_STANDARD 20)
 set(CMAKE_CXX_EXTENSIONS ON)
 set(CMAKE_EXPORT_COMPILE_COMMANDS ON)
 
-set(CMAKE_CXX_FLAGS "-fdiagnostics-color=always")
+set(CMAKE_CXX_FLAGS "-fdiagnostics-color=always -fbracket-depth=512")
 set(CMAKE_THREAD_PREFER_PTHREAD TRUE)
 find_package(Threads)
 link_libraries(Threads::Threads)
@@ -58,7 +58,7 @@ target_include_directories(eos-vm
                            INTERFACE ${CMAKE_CURRENT_SOURCE_DIR}/include
                                      ${CMAKE_CURRENT_SOURCE_DIR}/external/softfloat/source/include)
 # ignore the C++17 register warning until clean up
-target_compile_options( eos-vm INTERFACE $<$<COMPILE_LANGUAGE:CXX>:-Wno-register> )
+target_compile_options( eos-vm INTERFACE $<$<COMPILE_LANGUAGE:CXX>:-Wno-register> -fbracket-depth=512 )
 
 # ##################################################################################################
 # Enable debugging stats for eos-vm.

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -21,7 +21,11 @@ set(CMAKE_CXX_STANDARD 20)
 set(CMAKE_CXX_EXTENSIONS ON)
 set(CMAKE_EXPORT_COMPILE_COMMANDS ON)
 
-set(CMAKE_CXX_FLAGS "-fdiagnostics-color=always -fbracket-depth=512")
+if(APPLE) # TODO check to see if we are clang or g++
+   set( CLANG_BRACKET_DEPTH -fbracket-depth=512)
+endif()
+
+set(CMAKE_CXX_FLAGS "-fdiagnostics-color=always ${CLANG_BRACKET_DEPTH}")
 set(CMAKE_THREAD_PREFER_PTHREAD TRUE)
 find_package(Threads)
 link_libraries(Threads::Threads)
@@ -58,7 +62,7 @@ target_include_directories(eos-vm
                            INTERFACE ${CMAKE_CURRENT_SOURCE_DIR}/include
                                      ${CMAKE_CURRENT_SOURCE_DIR}/external/softfloat/source/include)
 # ignore the C++17 register warning until clean up
-target_compile_options( eos-vm INTERFACE $<$<COMPILE_LANGUAGE:CXX>:-Wno-register> -fbracket-depth=512 )
+target_compile_options( eos-vm INTERFACE $<$<COMPILE_LANGUAGE:CXX>:-Wno-register> ${CLANG_BRACKET_DEPTH} )
 
 # ##################################################################################################
 # Enable debugging stats for eos-vm.

--- a/include/eosio/vm/parser.hpp
+++ b/include/eosio/vm/parser.hpp
@@ -355,7 +355,7 @@ namespace eosio { namespace vm {
       }
 
       static constexpr auto make_section_order() {
-         std::array<std::uint8_t, section_id::num_of_elems> result;
+         std::array<std::uint8_t, section_id::num_of_elems> result{};
          std::uint8_t i = 1;
          for (std::uint8_t sec : {type_section, import_section, function_section, table_section, memory_section, global_section, export_section, start_section, element_section, data_count_section, code_section, data_section}) {
             result[sec] = i++;


### PR DESCRIPTION
## Change Description
clang's default limit for the number of arguments a variant can hold is 256, but eosvm has a variant with over 500 types in it. There is a compiler switch to change the default which gets set if APPLE is detected.

## API Changes
- [ ] API Changes
<!-- checked [] = API changes; unchecked [ x] = no changes, ignore this section -->
<!-- If this PR introduces API changes, please describe the changes here. What will developers need to know before upgrading to this version? -->


## Documentation Additions
- [ ] Documentation Additions
<!-- checked [x] = Documentation changes; unchecked [ ] = no changes, ignore this section -->
<!-- Describe what must be added to the documentation after merge. -->
