### PR TITLE
add cstdint include

### DIFF
--- a/include/eosio/vm/utils.hpp
+++ b/include/eosio/vm/utils.hpp
@@ -1,5 +1,6 @@
 #pragma once
 
+#include <cstdint>
 #include <cstdlib>
 #include <functional>
 #include <fstream>


### PR DESCRIPTION
Needed this include when building with libstdc++ 16 to find a missing `uint8_t`