### PR TITLE
avoid macOS process-wide signal mask overwrite on longjmp

### DIFF
--- a/include/eosio/vm/signals.hpp
+++ b/include/eosio/vm/signals.hpp
@@ -165,7 +165,10 @@ namespace eosio { namespace vm {
       code_memory_range = code_allocator.get_code_span();
       memory_range = mem_allocator->get_span();
       int sig;
-      if((sig = sigsetjmp(dest, 1)) == 0) {
+      sigset_t old_sigmask;
+      pthread_sigmask(SIG_SETMASK, nullptr, &old_sigmask);
+      // modifications to locals after setjmp might not be preserved across longjmp
+      if((sig = sigsetjmp(dest, 0)) == 0) {
          // Note: Cannot use RAII, as non-trivial destructors w/ longjmp
          // have undefined behavior. [csetjmp.syn]
          //
@@ -174,13 +177,13 @@ namespace eosio { namespace vm {
          // signals to make sure that only our signal handler is executed
          // if the caller has previously blocked signals.
          old_signal_handler = std::atomic_exchange(&signal_dest, &dest);
-         sigset_t unblock_mask, old_sigmask; // Might not be preserved across longjmp
+         sigset_t unblock_mask;
          sigemptyset(&unblock_mask);
          sigaddset(&unblock_mask, SIGSEGV);
          sigaddset(&unblock_mask, SIGBUS);
          sigaddset(&unblock_mask, SIGFPE);
          sigaddset(&unblock_mask, SIGPROF);
-         pthread_sigmask(SIG_UNBLOCK, &unblock_mask, &old_sigmask);
+         pthread_sigmask(SIG_UNBLOCK, &unblock_mask, nullptr);
          try {
             f();
             pthread_sigmask(SIG_SETMASK, &old_sigmask, nullptr);
@@ -195,6 +198,7 @@ namespace eosio { namespace vm {
             throw;
          }
       } else {
+         pthread_sigmask(SIG_SETMASK, &old_sigmask, nullptr);
          std::atomic_store(&signal_dest, old_signal_handler);
          memory_range = old_memory_range;
          code_memory_range = old_code_memory_range;

--- a/tests/signals_tests.cpp
+++ b/tests/signals_tests.cpp
@@ -1,8 +1,10 @@
 #include <eosio/vm/signals.hpp>
 #include <chrono>
 #include <csignal>
+#include <future>
 #include <thread>
 #include <iostream>
+#include <poll.h>
 
 #include <catch2/catch.hpp>
 
@@ -88,4 +90,74 @@ TEST_CASE("Test signal handler forwarding", "[signal_handler_forward]") {
       std::raise(SIGFPE);
       CHECK(sig_handled == 142 + SIGFPE);
    }
+}
+
+static int signal_pipefds[2];
+static void signal_write_pipe(int) {
+   write(signal_pipefds[1], "", 1);
+}
+
+TEST_CASE("Test signal mask longjmp restoration", "[signal_mask_longjmp_restoration]") {
+   REQUIRE(pipe(signal_pipefds) == 0);
+   auto pipe_guard = eosio::vm::scope_guard{[&]{
+      close(signal_pipefds[0]);
+      close(signal_pipefds[1]);
+   }};
+
+   struct sigaction sa, old_sa;
+   sa.sa_handler = signal_write_pipe;
+   sigemptyset(&sa.sa_mask);
+   REQUIRE(sigaction(SIGTERM, &sa, &old_sa) == 0);
+   auto resore_orig_sigterm_guard = eosio::vm::scope_guard{[&]{
+      sigaction(SIGTERM, &old_sa, nullptr);
+   }};
+
+   std::promise<void> thread_running;
+   std::promise<void> thread_may_return;
+   std::thread t([&] {
+      //block everything except SIGTERM in this thread
+      sigset_t suspend_mask;
+      sigfillset(&suspend_mask);
+      sigdelset(&suspend_mask, SIGTERM);
+      pthread_sigmask(SIG_SETMASK, &suspend_mask, nullptr);
+
+      thread_running.set_value();
+      thread_may_return.get_future().get();
+   });
+   auto thread_guard = eosio::vm::scope_guard{[&] {
+      thread_may_return.set_value();
+      t.join();
+   }};
+
+   thread_running.get_future().get();
+
+   sigset_t old_mask;
+   //block SIGTERM on main thread
+   sigset_t set;
+   sigemptyset(&set);
+   sigaddset(&set, SIGTERM);
+   REQUIRE(pthread_sigmask(SIG_BLOCK, &set, &old_mask) == 0);
+   auto mask_guard = eosio::vm::scope_guard{[&] {
+      pthread_sigmask(SIG_SETMASK, &old_mask, nullptr);
+   }};
+
+   eosio::vm::growable_allocator code_alloc;
+   eosio::vm::wasm_allocator wasm_alloc;
+   eosio::vm::invoke_with_signal_handler([&]() {
+      volatile auto i = *wasm_alloc.get_base_ptr<unsigned char>();
+   }, [](int sig){}, code_alloc, &wasm_alloc);
+
+   //send SIGTERM to the process, it should be delivered to the signal handling thread
+   REQUIRE(kill(getpid(), SIGTERM) == 0);
+
+   pollfd pfd{
+      .fd = signal_pipefds[0],
+      .events = POLLIN,
+   };
+   int r = poll(&pfd, 1, 500);
+   REQUIRE(r == 1);
+   REQUIRE((pfd.revents & POLLIN) != 0);
+
+   char buf;
+   REQUIRE(read(signal_pipefds[0], &buf, 1) == 1);
 }


### PR DESCRIPTION
Recent nodeos versions suffer from a problem on macOS where after EOS VM does a longjmp recovery, it is impossible to shut down nodeos. It will not respond to a Ctrl-C or SIGTERM.

I tracked this down to very surprising behavior in macOS longjmp. On macOS, `sigprocmask()` sets the signal mask on every thread. Okay no issue there, we use `pthread_sigmask()`. But the problem is when `siglongjmp()` restores the signal mask it calls `sigprocmask()`! So whenever EOS VM would recover from a SEGV or BUS (from a long running transaction), it would overwrite all threads' signal mask with whatever the mask was on the thread that started the EOS VM execution.

The reason only recent nodeos were affected was because of the signal changes in VaultaFoundation/mandel-appbase#2 that steer SIGINT, SIGTERM, etc on to a separate 'signal thread'. Thus it is easy to see how `siglongjmp()` then copies the mask from the main thread to this signal thread, masking these process wide.

We aren't the first to find this trap by a long shot. I stumbled on an ancient qemu commit qemu/qemu@6ab7e54 that actually describes the exact same failure mode.

The fix is to simply pass 0 to `sigsetjmp()`, and then restore the mask on our own (which we already had to do manually for the non-longjmp cases anyway). A test is included that will fail on macOS prior to the fix. I only tested on macOS 15 I was unable to test on 26 at the moment.